### PR TITLE
Fix for fread terminating before  is read. See http://php.net/manual/…

### DIFF
--- a/redis_session.php
+++ b/redis_session.php
@@ -365,7 +365,7 @@ if (!class_exists('iRedis')){
 				// If the amount left to read is less than 1024 then just read the rest, else read 1024
 				$block_size = ($size - $read) > 1024 ? 1024 : ($size - $read);
 				$response .= fread($this->connection, $block_size);
-				$read += $block_size;
+				$read = strlen($response);
 			}
 			// Get rid of the CRLF at the end
 			fread($this->connection, 2);


### PR DESCRIPTION
Fix for fread90 terminating before $block_size is read. See http://php.net/manual/en/function.fread.php for conditions that may lead to fread() terminating before length parameter."
[master 53f32c8] Fix for fread terminating before  is read. See http://php.net/manual/en/function.fread.php for conditions that may lead to fread() terminating before length parameter. Assumptions are bad..
